### PR TITLE
fixes issue #120 dry days legend was displaying Degree Days

### DIFF
--- a/resources/js/scenarioComparisonMap.js
+++ b/resources/js/scenarioComparisonMap.js
@@ -297,7 +297,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
             rightScenario: 'rcp85',
           },
           disabledScenarios: ['historical'],
-          legend_unit: 'Degree Days',
+          legend_unit: 'Dry Days',
         },
         'hdd_65f': {
           title: 'Heating Degree Days',


### PR DESCRIPTION
dry days legend was displaying Degree Days, was in json config for scenarioComparisonMap.js. Change here https://github.com/nemac/climate-explorer/blob/master/resources/js/scenarioComparisonMap.js#L300